### PR TITLE
perf: use Node.js crypto sha256 hasher for aggregate building

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3675,11 +3675,13 @@
       }
     },
     "node_modules/@ipld/dag-cbor": {
-      "version": "9.0.6",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.1.tgz",
+      "integrity": "sha512-nyY48yE7r3dnJVlxrdaimrbloh4RokQaNRdI//btfTkcTEZbpmSrbYcBQ4VKTf8ZxXAOUJy4VsRpkJo+y9RTnA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "cborg": "^4.0.0",
-        "multiformats": "^12.0.1"
+        "multiformats": "^13.1.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -3694,12 +3696,10 @@
       }
     },
     "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "12.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.0.tgz",
+      "integrity": "sha512-CBiqvsufgmpo01VT5ze94O+uc+Pbf6f/sThlvWss0sBZmAOu6GQn5usrYV2sf2mr17FWYc0rO8c/CNe2T90QAA==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@ipld/dag-json": {
       "version": "10.1.5",
@@ -6041,9 +6041,9 @@
       }
     },
     "node_modules/@web3-storage/filecoin-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/filecoin-api/-/filecoin-api-7.2.0.tgz",
-      "integrity": "sha512-0tr+vlLXQn4vbHZR2Sxxr62fKW60TejQyH3ZG1CNCFLhLkBg4pXTYSu5rxijYg3ob8DHkejKp7hXMgPQhFzOHw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/filecoin-api/-/filecoin-api-7.3.0.tgz",
+      "integrity": "sha512-1D4MFmHYMVCzxiIKFMVqVnIsJq0UbFJTC9ynm6i7eIJivoI3B/SJXmzkseXL1TyD/yxAXwa2fQysjz6/SwN2bg==",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
         "@ucanto/client": "^9.0.1",
@@ -6053,7 +6053,7 @@
         "@ucanto/transport": "^9.1.1",
         "@web3-storage/capabilities": "^17.2.0",
         "@web3-storage/content-claims": "^5.0.0",
-        "@web3-storage/data-segment": "^4.0.0",
+        "@web3-storage/data-segment": "^5.2.0",
         "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.3.0",
         "p-map": "^6.0.0"
       },
@@ -6095,14 +6095,21 @@
       }
     },
     "node_modules/@web3-storage/filecoin-api/node_modules/@web3-storage/data-segment": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/data-segment/-/data-segment-4.0.0.tgz",
-      "integrity": "sha512-AnNyJp3wHMa7LBzguQzm4rmXSi8vQBz4uFs+jiXnSNtLR5dAqHfhMvi9XdWonWPYvxNvT5ZhYCSF0mpDjymqKg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/data-segment/-/data-segment-5.2.0.tgz",
+      "integrity": "sha512-Jr/bdweoEQ0lWIaNuFcYxM6BHYmXHBWwfXygHyp370agkAdU+dIFIbm+tX+66XP/1YmEUi4JI2I80psDtoJ++Q==",
+      "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@ipld/dag-cbor": "^9.0.5",
-        "multiformats": "^11.0.2",
+        "@ipld/dag-cbor": "^9.2.1",
+        "multiformats": "^13.3.0",
         "sync-multihash-sha2": "^1.0.0"
       }
+    },
+    "node_modules/@web3-storage/filecoin-api/node_modules/@web3-storage/data-segment/node_modules/multiformats": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.0.tgz",
+      "integrity": "sha512-CBiqvsufgmpo01VT5ze94O+uc+Pbf6f/sThlvWss0sBZmAOu6GQn5usrYV2sf2mr17FWYc0rO8c/CNe2T90QAA==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@web3-storage/filecoin-api/node_modules/p-map": {
       "version": "6.0.0",
@@ -15977,9 +15984,10 @@
         "@ucanto/transport": "^9.1.1",
         "@w3filecoin/core": "*",
         "@web3-storage/data-segment": "5.0.0",
-        "@web3-storage/filecoin-api": "^7.2.0",
+        "@web3-storage/filecoin-api": "^7.3.0",
         "@web3-storage/filecoin-client": "3.3.3",
         "lru-cache": "^11.0.1",
+        "multiformats": "^13.3.0",
         "uint8arrays": "^4.0.6"
       },
       "devDependencies": {
@@ -16080,6 +16088,16 @@
         "sync-multihash-sha2": "^1.0.0"
       }
     },
+    "packages/functions/node_modules/@web3-storage/data-segment/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "license": "Apache-2.0 OR MIT",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "packages/functions/node_modules/lru-cache": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
@@ -16088,6 +16106,12 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "packages/functions/node_modules/multiformats": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.0.tgz",
+      "integrity": "sha512-CBiqvsufgmpo01VT5ze94O+uc+Pbf6f/sThlvWss0sBZmAOu6GQn5usrYV2sf2mr17FWYc0rO8c/CNe2T90QAA==",
+      "license": "Apache-2.0 OR MIT"
     },
     "packages/functions/node_modules/tslib": {
       "version": "1.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "@storacha/one-webcrypto": "^1.0.1"
+      },
       "devDependencies": {
         "@ipld/dag-ucan": "3.4.0",
         "@sentry/serverless": "^7.52.1",
@@ -5108,6 +5111,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@storacha/one-webcrypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@storacha/one-webcrypto/-/one-webcrypto-1.0.1.tgz",
+      "integrity": "sha512-bD+vWmcgsEBqU0Dz04BR43SA03bBoLTAY29vaKasY9Oe8cb6XIP0/vkm0OS2UwKC13c8uRgFW4rjJUgDCNLejQ==",
+      "license": "MIT"
     },
     "node_modules/@trpc/server": {
       "version": "9.16.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "sst": "^2.17.2",
     "typescript": "^4.9.4"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@storacha/one-webcrypto": "^1.0.1"
+  },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
   },

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -12,9 +12,10 @@
     "@ucanto/transport": "^9.1.1",
     "@w3filecoin/core": "*",
     "@web3-storage/data-segment": "5.0.0",
-    "@web3-storage/filecoin-api": "^7.2.0",
+    "@web3-storage/filecoin-api": "^7.3.0",
     "@web3-storage/filecoin-client": "3.3.3",
     "lru-cache": "^11.0.1",
+    "multiformats": "^13.3.0",
     "uint8arrays": "^4.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR switches from JS native sha256 hashing to hashing provided by the Node.js crypto module, which is significantly faster.