### PR TITLE
feat: add HTTP principal resolver

### DIFF
--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -11,6 +11,7 @@
     "@ipld/dag-ucan": "catalog:",
     "@storacha/filecoin-api": "catalog:",
     "@storacha/filecoin-client": "catalog:",
+    "@storacha/principal-resolver": "catalog:",
     "@types/aws-lambda": "catalog:",
     "@ucanto/core": "catalog:",
     "@ucanto/server": "catalog:",

--- a/packages/functions/src/aggregator-api/ucan-invocation-router.js
+++ b/packages/functions/src/aggregator-api/ucan-invocation-router.js
@@ -4,7 +4,7 @@ import { Table } from 'sst/node/table'
 // eslint-disable-next-line no-unused-vars
 import * as CAR from '@ucanto/transport/car'
 import * as Server from '@ucanto/server'
-
+import { HTTPResolver } from '@storacha/principal-resolver'
 import { connect as ucanLogConnect } from '@w3filecoin/core/src/ucan-log.js'
 // store clients
 import { createClient as createAggregateStoreClient } from '@w3filecoin/core/src/store/aggregator-aggregate-store.js'
@@ -120,6 +120,8 @@ function getContext () {
     pieceAcceptQueueRegion
   } = getLambdaEnv()
 
+  const principalResolver = HTTPResolver.create([/^did:web:.*\.storacha\.network$/])
+
   return {
     id: getServiceSigner({ did, privateKey }),
     dealerId: getPrincipal(dealerDid),
@@ -161,6 +163,7 @@ function getContext () {
       { region: pieceAcceptQueueRegion },
       { queueUrl: pieceAcceptQueueUrl }
     ),
+    ...principalResolver,
     // TODO: integrate with revocations
     validateAuthorization: () => ({ ok: {} })
   }

--- a/packages/functions/src/deal-tracker-api/ucan-invocation-router.js
+++ b/packages/functions/src/deal-tracker-api/ucan-invocation-router.js
@@ -3,7 +3,7 @@ import { Config } from 'sst/node/config'
 import { Table } from 'sst/node/table'
 import * as CAR from '@ucanto/transport/car'
 import * as Server from '@ucanto/server'
-
+import { HTTPResolver } from '@storacha/principal-resolver'
 import { connect as ucanLogConnect } from '@w3filecoin/core/src/ucan-log.js'
 import { createClient } from '@w3filecoin/core/src/store/deal-store.js'
 import { getServiceSigner } from '@w3filecoin/core/src/service.js'
@@ -52,6 +52,8 @@ export async function ucanInvocationRouter (request) {
     }
   )
 
+  const principalResolver = HTTPResolver.create([/^did:web:.*\.storacha\.network$/])
+
   const server = createServer({
     id: serviceSigner,
     dealStore,
@@ -61,6 +63,7 @@ export async function ucanInvocationRouter (request) {
         Sentry.AWSLambda.captureException(err)
       }
     },
+    ...principalResolver,
     // TODO: integrate with revocations
     validateAuthorization: () => ({ ok: {} })
   })

--- a/packages/functions/src/dealer-api/ucan-invocation-router.js
+++ b/packages/functions/src/dealer-api/ucan-invocation-router.js
@@ -6,7 +6,7 @@ import { fromString } from 'uint8arrays/from-string'
 import * as DID from '@ipld/dag-ucan/did'
 import * as CAR from '@ucanto/transport/car'
 import * as Server from '@ucanto/server'
-
+import { HTTPResolver } from '@storacha/principal-resolver'
 import { connect as ucanLogConnect } from '@w3filecoin/core/src/ucan-log.js'
 import { createClient as createAggregateStoreClient } from '@w3filecoin/core/src/store/dealer-aggregate-store.js'
 import { createClient as createOfferStoreClient } from '@w3filecoin/core/src/store/dealer-offer-store.js'
@@ -93,6 +93,8 @@ export async function ucanInvocationRouter (request) {
     issuer = issuer.withDID(DID.parse(did).did())
   }
 
+  const principalResolver = HTTPResolver.create([/^did:web:.*\.storacha\.network$/])
+
   const server = createServer({
     id: issuer,
     aggregateStore,
@@ -112,6 +114,7 @@ export async function ucanInvocationRouter (request) {
         Sentry.AWSLambda.captureException(err)
       }
     },
+    ...principalResolver,
     // TODO: integrate with revocations
     validateAuthorization: () => ({ ok: {} })
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^1.12.0
       version: 1.12.0
     '@storacha/filecoin-api':
-      specifier: ^1.3.4-rc.0
-      version: 1.3.4-rc.0
+      specifier: ^1.3.4
+      version: 1.3.4
     '@storacha/filecoin-client':
       specifier: ^1.0.15
       version: 1.0.15
@@ -43,8 +43,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@storacha/principal-resolver':
-      specifier: ^1.0.0-rc.1
-      version: 1.0.0-rc.1
+      specifier: ^1.0.0
+      version: 1.0.0
     '@storacha/upload-api':
       specifier: ^2.6.1
       version: 2.6.2
@@ -179,7 +179,7 @@ importers:
         version: 7.114.0
       '@storacha/filecoin-api':
         specifier: 'catalog:'
-        version: 1.3.4-rc.0
+        version: 1.3.4
       '@storacha/filecoin-client':
         specifier: 'catalog:'
         version: 1.0.15
@@ -284,7 +284,7 @@ importers:
         version: 1.12.0
       '@storacha/filecoin-api':
         specifier: 'catalog:'
-        version: 1.3.4-rc.0
+        version: 1.3.4
       '@storacha/filecoin-client':
         specifier: 'catalog:'
         version: 1.0.15
@@ -372,13 +372,13 @@ importers:
         version: 3.4.5
       '@storacha/filecoin-api':
         specifier: 'catalog:'
-        version: 1.3.4-rc.0
+        version: 1.3.4
       '@storacha/filecoin-client':
         specifier: 'catalog:'
         version: 1.0.15
       '@storacha/principal-resolver':
         specifier: 'catalog:'
-        version: 1.0.0-rc.1
+        version: 1.0.0
       '@types/aws-lambda':
         specifier: 'catalog:'
         version: 8.10.158
@@ -427,7 +427,7 @@ importers:
         version: 3.4.5
       '@storacha/filecoin-api':
         specifier: 'catalog:'
-        version: 1.3.4-rc.0
+        version: 1.3.4
       '@storacha/filecoin-client':
         specifier: 'catalog:'
         version: 1.0.15
@@ -2864,12 +2864,8 @@ packages:
     resolution: {integrity: sha512-0ee1t15yG4xdyIYz2iL+wP06VnGQf8zJ/xpszjf4sdP2sTgAVzx92LfEgHcuIbFF4sabcJXzHFAcMi8l8u64Mg==}
     engines: {node: '>=16.15'}
 
-  '@storacha/filecoin-api@1.3.1':
-    resolution: {integrity: sha512-DldDzx052JZbWiJXdoLFdLDEgTNBrQ1EPG6iQgGYqWT9F8yIWgXRlJDA9bl26BnllvpBJ1A6q2f7ld/ELGYBYA==}
-    engines: {node: '>=16.15'}
-
-  '@storacha/filecoin-api@1.3.4-rc.0':
-    resolution: {integrity: sha512-1pS/J8izR/HHxY0t24aMAqQJ09ogqQPyWkFcPyn7uNSpukVycFXlGF3PwdOY3GFWFPwhwpGyFkHPyfJ02kTLFw==}
+  '@storacha/filecoin-api@1.3.4':
+    resolution: {integrity: sha512-Rhn8jiOdVSXiBfOP283VCvDiV1lMdVzNkBXSZM0uOylFPb0ZMN4xHuU/boXKcpA/f36+Hmiwy+gOFpVTxqNs7w==}
     engines: {node: '>=16.15'}
 
   '@storacha/filecoin-client@1.0.15':
@@ -2881,8 +2877,8 @@ packages:
   '@storacha/one-webcrypto@1.0.1':
     resolution: {integrity: sha512-bD+vWmcgsEBqU0Dz04BR43SA03bBoLTAY29vaKasY9Oe8cb6XIP0/vkm0OS2UwKC13c8uRgFW4rjJUgDCNLejQ==}
 
-  '@storacha/principal-resolver@1.0.0-rc.1':
-    resolution: {integrity: sha512-9pe/LMKFQ1OQYQz14TFGgqiP+ZvQ2g0IdkS4UMPA7il9hb0NlwQQXUsTcfEFSIajOZYD1UMGN+3IGLwcH/nEZw==}
+  '@storacha/principal-resolver@1.0.0':
+    resolution: {integrity: sha512-arw/iRf4PKWL7qty5ZjzNLB+Tf9onoMNB7g0JxoA8p5JZZ0lm/vKgxETDI2OXlO5PqlfFlwDZ0/ZohZUseZ3ug==}
 
   '@storacha/router@1.0.0':
     resolution: {integrity: sha512-Mg5FcF2yT9ZMcdlIB/xtEG2YC6LdfGzh/NiQsdTyB7ewO9CajaqzQ7ZH0NNyLJtVeDoVjzr98R1OXDetWMFfXQ==}
@@ -13577,21 +13573,7 @@ snapshots:
 
   '@storacha/did-mailto@1.0.2': {}
 
-  '@storacha/filecoin-api@1.3.1':
-    dependencies:
-      '@ipld/dag-ucan': 3.4.5
-      '@storacha/capabilities': 1.12.0
-      '@ucanto/client': 9.0.2
-      '@ucanto/core': 10.4.6
-      '@ucanto/interface': 11.0.1
-      '@ucanto/server': 11.0.3
-      '@ucanto/transport': 9.2.1
-      '@web3-storage/content-claims': 5.2.4
-      '@web3-storage/data-segment': 5.3.0
-      fr32-sha2-256-trunc254-padded-binary-tree-multihash: 3.3.0
-      p-map: 6.0.0
-
-  '@storacha/filecoin-api@1.3.4-rc.0':
+  '@storacha/filecoin-api@1.3.4':
     dependencies:
       '@ipld/dag-ucan': 3.4.5
       '@storacha/capabilities': 1.12.0
@@ -13628,7 +13610,7 @@ snapshots:
 
   '@storacha/one-webcrypto@1.0.1': {}
 
-  '@storacha/principal-resolver@1.0.0-rc.1':
+  '@storacha/principal-resolver@1.0.0':
     dependencies:
       '@ipld/dag-ucan': 3.4.5
       '@ucanto/interface': 11.0.1
@@ -13651,7 +13633,7 @@ snapshots:
       '@storacha/blob-index': 1.2.4
       '@storacha/capabilities': 1.12.0
       '@storacha/did-mailto': 1.0.2
-      '@storacha/filecoin-api': 1.3.1
+      '@storacha/filecoin-api': 1.3.4
       '@storacha/indexing-service-client': 2.6.9
       '@storacha/router': 1.0.0
       '@ucanto/client': 9.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,14 +34,17 @@ catalogs:
       specifier: ^1.12.0
       version: 1.12.0
     '@storacha/filecoin-api':
-      specifier: ^1.3.1
-      version: 1.3.1
+      specifier: ^1.3.4-rc.0
+      version: 1.3.4-rc.0
     '@storacha/filecoin-client':
       specifier: ^1.0.15
       version: 1.0.15
     '@storacha/one-webcrypto':
       specifier: ^1.0.1
       version: 1.0.1
+    '@storacha/principal-resolver':
+      specifier: ^1.0.0-rc.1
+      version: 1.0.0-rc.1
     '@storacha/upload-api':
       specifier: ^2.6.1
       version: 2.6.2
@@ -176,7 +179,7 @@ importers:
         version: 7.114.0
       '@storacha/filecoin-api':
         specifier: 'catalog:'
-        version: 1.3.1
+        version: 1.3.4-rc.0
       '@storacha/filecoin-client':
         specifier: 'catalog:'
         version: 1.0.15
@@ -281,7 +284,7 @@ importers:
         version: 1.12.0
       '@storacha/filecoin-api':
         specifier: 'catalog:'
-        version: 1.3.1
+        version: 1.3.4-rc.0
       '@storacha/filecoin-client':
         specifier: 'catalog:'
         version: 1.0.15
@@ -369,10 +372,13 @@ importers:
         version: 3.4.5
       '@storacha/filecoin-api':
         specifier: 'catalog:'
-        version: 1.3.1
+        version: 1.3.4-rc.0
       '@storacha/filecoin-client':
         specifier: 'catalog:'
         version: 1.0.15
+      '@storacha/principal-resolver':
+        specifier: 'catalog:'
+        version: 1.0.0-rc.1
       '@types/aws-lambda':
         specifier: 'catalog:'
         version: 8.10.158
@@ -421,7 +427,7 @@ importers:
         version: 3.4.5
       '@storacha/filecoin-api':
         specifier: 'catalog:'
-        version: 1.3.1
+        version: 1.3.4-rc.0
       '@storacha/filecoin-client':
         specifier: 'catalog:'
         version: 1.0.15
@@ -2862,6 +2868,10 @@ packages:
     resolution: {integrity: sha512-DldDzx052JZbWiJXdoLFdLDEgTNBrQ1EPG6iQgGYqWT9F8yIWgXRlJDA9bl26BnllvpBJ1A6q2f7ld/ELGYBYA==}
     engines: {node: '>=16.15'}
 
+  '@storacha/filecoin-api@1.3.4-rc.0':
+    resolution: {integrity: sha512-1pS/J8izR/HHxY0t24aMAqQJ09ogqQPyWkFcPyn7uNSpukVycFXlGF3PwdOY3GFWFPwhwpGyFkHPyfJ02kTLFw==}
+    engines: {node: '>=16.15'}
+
   '@storacha/filecoin-client@1.0.15':
     resolution: {integrity: sha512-VO/QdK4rIyX46YFThm3itR8JmpZ1YznJpb/+9DjH1zbKuIMl+f2w7d+v8YFacYJzgniVuexn2sCNjQmNMogbUg==}
 
@@ -2870,6 +2880,9 @@ packages:
 
   '@storacha/one-webcrypto@1.0.1':
     resolution: {integrity: sha512-bD+vWmcgsEBqU0Dz04BR43SA03bBoLTAY29vaKasY9Oe8cb6XIP0/vkm0OS2UwKC13c8uRgFW4rjJUgDCNLejQ==}
+
+  '@storacha/principal-resolver@1.0.0-rc.1':
+    resolution: {integrity: sha512-9pe/LMKFQ1OQYQz14TFGgqiP+ZvQ2g0IdkS4UMPA7il9hb0NlwQQXUsTcfEFSIajOZYD1UMGN+3IGLwcH/nEZw==}
 
   '@storacha/router@1.0.0':
     resolution: {integrity: sha512-Mg5FcF2yT9ZMcdlIB/xtEG2YC6LdfGzh/NiQsdTyB7ewO9CajaqzQ7ZH0NNyLJtVeDoVjzr98R1OXDetWMFfXQ==}
@@ -13578,6 +13591,20 @@ snapshots:
       fr32-sha2-256-trunc254-padded-binary-tree-multihash: 3.3.0
       p-map: 6.0.0
 
+  '@storacha/filecoin-api@1.3.4-rc.0':
+    dependencies:
+      '@ipld/dag-ucan': 3.4.5
+      '@storacha/capabilities': 1.12.0
+      '@ucanto/client': 9.0.2
+      '@ucanto/core': 10.4.6
+      '@ucanto/interface': 11.0.1
+      '@ucanto/server': 11.0.3
+      '@ucanto/transport': 9.2.1
+      '@web3-storage/content-claims': 5.2.4
+      '@web3-storage/data-segment': 5.3.0
+      fr32-sha2-256-trunc254-padded-binary-tree-multihash: 3.3.0
+      p-map: 6.0.0
+
   '@storacha/filecoin-client@1.0.15':
     dependencies:
       '@ipld/dag-ucan': 3.4.5
@@ -13600,6 +13627,12 @@ snapshots:
       multiformats: 13.4.1
 
   '@storacha/one-webcrypto@1.0.1': {}
+
+  '@storacha/principal-resolver@1.0.0-rc.1':
+    dependencies:
+      '@ipld/dag-ucan': 3.4.5
+      '@ucanto/interface': 11.0.1
+      '@ucanto/validator': 10.0.1
 
   '@storacha/router@1.0.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,9 +11,10 @@ catalog:
   '@ipld/dag-ucan': ^3.4.5
   '@sentry/serverless': ^7.74.1
   '@storacha/capabilities': ^1.12.0
-  '@storacha/filecoin-api': ^1.3.1
+  '@storacha/filecoin-api': ^1.3.4-rc.0
   '@storacha/filecoin-client': ^1.0.15
   '@storacha/one-webcrypto': ^1.0.1
+  '@storacha/principal-resolver': ^1.0.0-rc.1
   '@storacha/upload-api': ^2.6.1
   '@tsconfig/node16': ^1.0.3
   '@types/aws-lambda': ^8.10.158

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,10 +11,10 @@ catalog:
   '@ipld/dag-ucan': ^3.4.5
   '@sentry/serverless': ^7.74.1
   '@storacha/capabilities': ^1.12.0
-  '@storacha/filecoin-api': ^1.3.4-rc.0
+  '@storacha/filecoin-api': ^1.3.4
   '@storacha/filecoin-client': ^1.0.15
   '@storacha/one-webcrypto': ^1.0.1
-  '@storacha/principal-resolver': ^1.0.0-rc.1
+  '@storacha/principal-resolver': ^1.0.0
   '@storacha/upload-api': ^2.6.1
   '@tsconfig/node16': ^1.0.3
   '@types/aws-lambda': ^8.10.158


### PR DESCRIPTION
This PR allows the filecoin pipeline to validate invocations and delegations signed by `did:web` agents.